### PR TITLE
[Feature] Set proper ID on inputs and labels + custom

### DIFF
--- a/addon/mixins/lf-input-mixin.js
+++ b/addon/mixins/lf-input-mixin.js
@@ -8,6 +8,10 @@ export default Mixin.create({
   name: null, //passed in
   property: null, //passed in
 
+  id: computed('inputId', function() {
+    return this.get('inputId') || `ember${Ember.uuid()}`;
+  }),
+
   /**
    * This property determines whether errors should be displayed
    *

--- a/addon/templates/components/lf-bootstrap-label.hbs
+++ b/addon/templates/components/lf-bootstrap-label.hbs
@@ -1,3 +1,3 @@
 {{#if label}}
-  <label class="control-label">{{label}}</label>
+  <label for={{labelFor}} class="control-label">{{label}}</label>
 {{/if}}

--- a/addon/templates/components/lf-bootstrap-wrapper.hbs
+++ b/addon/templates/components/lf-bootstrap-wrapper.hbs
@@ -1,5 +1,5 @@
 {{#if label}}
-  <label class="control-label">{{label}}</label>
+  <label for={{labelFor}} class="control-label">{{label}}</label>
 {{/if}}
 
 {{yield}}

--- a/addon/templates/components/lf-input-wrapper.hbs
+++ b/addon/templates/components/lf-input-wrapper.hbs
@@ -1,4 +1,4 @@
-{{component labelComponent label=label}}
+{{component labelComponent label=label labelFor=labelFor}}
 
 {{yield}}
 

--- a/addon/templates/components/lf-input.hbs
+++ b/addon/templates/components/lf-input.hbs
@@ -1,6 +1,7 @@
 {{#lf-input-wrapper
   errorMessages=errorMessages
   label=label
+  labelFor=id
   labelComponent=labelComponent
   errorMessagesComponent=errorMessagesComponent
   showErrorMessages=validationStateVisible
@@ -9,6 +10,7 @@
     <div class="input-group">
       {{yield}}
       {{one-way-input
+        id=id
         value=property
         update=(action "valueChanged")
         placeholder=placeholder
@@ -20,6 +22,7 @@
     </div>
   {{else}}
       {{one-way-input
+        id=id
         value=property
         update=(action "valueChanged")
         placeholder=placeholder

--- a/addon/templates/components/lf-select.hbs
+++ b/addon/templates/components/lf-select.hbs
@@ -1,11 +1,12 @@
 {{#lf-input-wrapper
   label=label
+  labelFor=id
   errorMessages=errorMessages
   labelComponent=labelComponent
   errorMessagesComponent=errorMessagesComponent
   showErrorMessages=showErrorMessages
 }}
-  <select class="form-control" onchange={{action "optionSelected" value="target.value"}}>
+  <select class="form-control" id={{id}} onchange={{action "optionSelected" value="target.value"}}>
     <option value="">{{prompt}}</option>
     {{#each content as |item|}}
       <option value={{get item valuePath}} selected={{eq property (get item valuePath)}}>{{get item labelPath}}</option>

--- a/addon/templates/components/lf-textarea.hbs
+++ b/addon/templates/components/lf-textarea.hbs
@@ -1,11 +1,13 @@
 {{#lf-input-wrapper
   errorMessages=errorMessages
   label=label
+  labelFor=id
   labelComponent=labelComponent
   errorMessagesComponent=errorMessagesComponent
   showErrorMessages=showErrorMessages
 }}
   {{one-way-textarea
+    id=id
     value=property
     class="form-control"
     update=(action "valueChanged")

--- a/tests/integration/components/lf-input-test.js
+++ b/tests/integration/components/lf-input-test.js
@@ -20,11 +20,37 @@ function setupInput(context, isValid = true, updateAction = null) {
   }}`);
 }
 
-test('it renders the input with all markup',function(assert) {
+test('it renders the input with all markup', function(assert) {
   setupInput(this);
 
   assert.equal(this.$('.control-label').text().trim(), 'Name', 'it has proper label');
   assert.equal(this.$('.form-group').length, 1, 'it has a form-group div');
+});
+
+test('it has proper `for` attribute set on label', function(assert) {
+  setupInput(this);
+
+  assert.equal(this.$('.control-label').attr('for'), this.$('.form-control').attr('id'),
+    'it has proper `for` attribute set');
+});
+
+test('it passes custom `id` to inner input and label', function(assert) {
+  setupInput(this);
+
+  this.render(hbs`{{lf-input
+    inputId="uniqueId"
+    label="Name"
+    property=name
+    name="name"
+    validate=(action validateAction)
+    on-update=(action onUpdate)
+  }}`);
+
+  assert.equal(this.$('.control-label').attr('for'), 'uniqueId',
+    'it has proper id set in label\'s `for` attribute');
+
+  assert.equal(this.$('.form-control').attr('id'), 'uniqueId',
+    'it has proper id set on input');
 });
 
 test('it has no validation state when rendered', function(assert) {
@@ -54,6 +80,7 @@ test('it shows success validation state', function(assert) {
 
 test('it resets validation state when property set to null', function(assert) {
   setupInput(this);
+
   this.set('name', null);
   let $form = this.$('.form-group');
 

--- a/tests/integration/components/lf-select-test.js
+++ b/tests/integration/components/lf-select-test.js
@@ -44,6 +44,35 @@ test(
   }
 );
 
+test('it has proper `for` attribute set on label', function(assert) {
+  setupSelect(this);
+
+  assert.equal(this.$('.control-label').attr('for'), this.$('select.form-control').attr('id'),
+    'it has proper `for` attribute set');
+});
+
+test('it passes custom `id` to inner select and label', function(assert) {
+  setupSelect(this);
+
+  this.render(hbs`{{lf-select
+    inputId="uniqueId"
+    label="Select"
+    property=value
+    content=options
+    name="value"
+    valuePath="id"
+    labelPath="name"
+    validate=(action validateAction)
+    on-update=(action onUpdate)
+  }}`);
+
+  assert.equal(this.$('.control-label').attr('for'), 'uniqueId',
+    'it has proper id set in label\'s `for` attribute');
+
+  assert.equal(this.$('select.form-control').attr('id'), 'uniqueId',
+    'it has proper id set on select');
+});
+
 test('it has no validation state when rendered', function(assert) {
   setupSelect(this);
 

--- a/tests/integration/components/lf-textarea-test.js
+++ b/tests/integration/components/lf-textarea-test.js
@@ -41,6 +41,32 @@ test(
   }
 );
 
+test('it has proper `for` attribute set on label', function(assert) {
+  setupTextarea(this);
+
+  assert.equal(this.$('.control-label').attr('for'), this.$('.form-control').attr('id'),
+    'it has proper `for` attribute set');
+});
+
+test('it passes custom `id` to inner textarea and label', function(assert) {
+  setupTextarea(this);
+
+  this.render(hbs`{{lf-textarea
+    inputId="uniqueId"
+    label="Description"
+    property=description
+    name="value"
+    validate=(action validateAction)
+    on-update=(action onUpdate)
+  }}`);
+
+  assert.equal(this.$('.control-label').attr('for'), 'uniqueId',
+    'it has proper id set in label\'s `for` attribute');
+
+  assert.equal(this.$('.form-control').attr('id'), 'uniqueId',
+    'it has proper id set on textarea');
+});
+
 test('it has no validation state when rendered', function(assert) {
   setupTextarea(this);
 


### PR DESCRIPTION
Hi @jbandura 

I was working now for some time using extensively your plugin. It's a breeze :)

I do however encountered an issue.
I wanted to improve accessibility and have proper `for` attribute on `label` that corresponds to `id` on input.

First I had:
```
<label for="some-id">Lorem ipsum</label>
{{lf-input
    id="some-id"
    name='assetUrl'
    property=asset.url
    on-update=(action (mut asset.url))
    validate=validateFunc
}}
```
But setting ID on `lf-input` or any other component was setting it on outer `div` inside the component, not the actual `input`.

So I added the possibility to use it like this:
```diff
<label for="some-id">Lorem ipsum</label>
{{lf-input
-   id='some-id'
+   inputId='some-id'
    name='assetUrl'
    property=asset.url
    on-update=(action (mut asset.url))
    validate=validateFunc
}}
```
And now it sets proper ID on `input`.

Then I also removed my `label` and used the one you prepared in `input-wrapper`:
```diff
{{lf-input
    inputId='some-id'
+   label='Lorem ipsum'
    name='assetUrl'
    property=asset.url
    on-update=(action (mut asset.url))
    validate=validateFunc
}}
```
I made sure that proper `for` attribute is set on any label generated by `ember-legit-forms`.

When you don't provide `inputID` it will just generate first free `emberID` and set it as `id` on input/select/textarea and `for` on label.

Example output:
```html
<!-- with `inputId` set -->
<div id="ember909" class="ember-view">
  <label class="control-label" for="some-id">Lorem ipsum</label>
  <input id="some-id" class="form-control ember-view">
</div>

<!-- with `inputId` not set -->
<div id="ember909" class="ember-view">
  <label class="control-label" for="ember889">Lorem ipsum</label>
  <input id="ember889" class="form-control ember-view">
</div>
```

Let me know what do you think about it. I'm happy to hear any suggestions :)

I added some test for this already.