### PR TITLE
Add prevent submit option

### DIFF
--- a/addon/components/lf-form.js
+++ b/addon/components/lf-form.js
@@ -43,7 +43,7 @@ export default Component.extend({
   submit(e) {
     e.preventDefault();
 
-    if (this.get('preventSubmit')) {
+    if (this.get('preventSubmit') && !this.get('formValid')) {
       this.get('eventDispatcher').trigger('lf-forceValidate');
     } else if (this.get('onSubmit')) {
       this.get('onSubmit')(this.get('formValid'));

--- a/addon/components/lf-form.js
+++ b/addon/components/lf-form.js
@@ -6,15 +6,19 @@ import getOwner from 'ember-getowner-polyfill';
 const {
   Component,
   computed,
-  observer
+  observer,
+  inject: { service },
 } = Ember;
 
 export default Component.extend({
+  eventDispatcher: service('lf-event-dispatcher'),
+
   layout,
   tagName: 'form',
   formValidator: null,
   rules: null, //passed in
   data: null, //passed in
+  preventSubmit: null, //passed in
   formValid: computed('formValidator.isFormValid', function() {
     if (this.get('formValidator')) {
       return this.get('formValidator.isFormValid');
@@ -38,7 +42,10 @@ export default Component.extend({
 
   submit(e) {
     e.preventDefault();
-    if (this.get('onSubmit')) {
+
+    if (this.get('preventSubmit')) {
+      this.get('eventDispatcher').trigger('lf-forceValidate');
+    } else if (this.get('onSubmit')) {
       this.get('onSubmit')(this.get('formValid'));
     }
   },

--- a/addon/mixins/lf-input-mixin.js
+++ b/addon/mixins/lf-input-mixin.js
@@ -1,8 +1,10 @@
 import Ember from 'ember';
 
-const { Mixin, computed, run } = Ember;
+const { Mixin, computed, run, inject: { service } } = Ember;
 
 export default Mixin.create({
+  eventDispatcher: service('lf-event-dispatcher'),
+
   classNames: ['form-group'],
   classNameBindings: ['validationState'],
   name: null, //passed in
@@ -59,9 +61,12 @@ export default Mixin.create({
 
   focusOut() {
     this._super(...arguments);
-    this.set('_edited', true);
-    this.validateField(this.get('property'));
-    this.showValidationState();
+    this.executeValidate();
+  },
+
+  init() {
+    this._super(...arguments);
+    this.get('eventDispatcher').on('lf-forceValidate', this, this.onForceValidate);
   },
 
   /**
@@ -77,6 +82,17 @@ export default Mixin.create({
 
       this.attrs.validate(this.get('name'), this.get('property'));
     });
+  },
+
+  willDestroyElement() {
+    this._super(...arguments);
+    this.get('eventDispatcher').off('lf-forceValidate', this, this.onForceValidate);
+  },
+
+  executeValidate() {
+    this.set('_edited', true);
+    this.validateField(this.get('property'));
+    this.showValidationState();
   },
 
   /**
@@ -130,5 +146,12 @@ export default Mixin.create({
 
   hideValidationState() {
     this.set('validationStateVisible', false);
-  }
+  },
+
+  /**
+   * 'lf-forceValidate' Event handler
+   */
+  onForceValidate() {
+    this.executeValidate();
+  },
 });

--- a/addon/services/lf-event-dispatcher.js
+++ b/addon/services/lf-event-dispatcher.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+const { Service, Evented } = Ember;
+
+export default Service.extend(Evented);

--- a/app/services/lf-event-dispatcher.js
+++ b/app/services/lf-event-dispatcher.js
@@ -1,0 +1,3 @@
+import LFEventDispatcher from 'ember-legit-forms/services/lf-event-dispatcher';
+
+export default LFEventDispatcher;

--- a/tests/integration/components/lf-form-test.js
+++ b/tests/integration/components/lf-form-test.js
@@ -23,3 +23,50 @@ test('it calls the on-submit action', function(assert){
   this.$('.js-submit').trigger('click');
 });
 
+test('it displays errors on submit when preventSubmit=true', function(assert){
+  assert.expect(3);
+
+  this.set('rules', {
+    input: 'required',
+    textarea: 'required',
+    select: 'required',
+  });
+
+  this.set('onSubmit', () => {
+    assert.ok(false, 'it shouldn\'t be called at all');
+  });
+
+  this.set('selectOptions', [
+    { id: 'val1', name: 'Value 1' },
+    { id: 'val2', name: 'Value 2' },
+  ]);
+
+  this.render(hbs`
+  {{#lf-form rules=rules onSubmit=(action onSubmit) preventSubmit=true as |v|}}
+    {{lf-input
+      class='js-input'
+      name='input'
+      validate=v
+    }}
+    {{lf-textarea
+      class='js-textarea'
+      name='textarea'
+      validate=v
+    }}
+    {{lf-select
+      content=selectOptions
+      name='select'
+      class='js-select'
+      valuePath='id'
+      labelPath='name'
+      validate=v
+    }}
+    <button class="js-submit">Submit</button>
+  {{/lf-form}}`);
+
+  this.$('.js-submit').trigger('click');
+
+  assert.ok(this.$('.js-input').hasClass('has-error'), 'it should display error on submit');
+  assert.ok(this.$('.js-textarea').hasClass('has-error'), 'it should display error on submit');
+  assert.ok(this.$('.js-select').hasClass('has-error'), 'it should display error on submit');
+});

--- a/tests/integration/components/lf-form-test.js
+++ b/tests/integration/components/lf-form-test.js
@@ -70,3 +70,28 @@ test('it displays errors on submit when preventSubmit=true', function(assert){
   assert.ok(this.$('.js-textarea').hasClass('has-error'), 'it should display error on submit');
   assert.ok(this.$('.js-select').hasClass('has-error'), 'it should display error on submit');
 });
+
+test('it allows to submit form when it\'s valid and preventSubmit=true', function(assert){
+  assert.expect(1);
+
+  this.set('rules', {
+    input: 'required',
+  });
+
+  this.set('onSubmit', () => {
+    assert.ok(true, 'action is called on submit');
+  });
+
+  this.render(hbs`
+  {{#lf-form rules=rules onSubmit=(action onSubmit) preventSubmit=true as |v|}}
+    {{lf-input
+      class='js-input'
+      name='input'
+      validate=v
+    }}
+    <button class="js-submit">Submit</button>
+  {{/lf-form}}`);
+
+  this.$('.js-input input').val('example value').trigger('change');
+  this.$('.js-submit').trigger('click');
+});


### PR DESCRIPTION
I added option `preventSubmit` that makes sure the form will be not submitted when it's not valid. Instead it will display all errors.

Example usage:
```
{{#lf-form onSubmit=(action 'login') preventSubmit=true rules=rules as |validateFunc|}}
{{/lf-form}}
```

I found it tricky to communicate and trigger actions on children components, so I used `Ember.Evented` to force validation on submit.

Let me know what do you think about it @jbandura. I'm happy to adjust it when needed.