### PR TITLE
use `getOwner` from ember and remove polyfill

### DIFF
--- a/addon/components/lf-form.js
+++ b/addon/components/lf-form.js
@@ -1,12 +1,12 @@
 import Ember from 'ember';
 import layout from '../templates/components/lf-form';
 import formValidator from '../utils/form-validator';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   Component,
   computed,
   observer,
+  getOwner,
   inject: { service },
 } = Ember;
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
-    "ember-getowner-polyfill": "1.0.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.1.2",


### PR DESCRIPTION
I was getting an error about not finding the polyfill in a recent project, which prompted me to look into this--seems like it's no longer necessary?