### PR TITLE
Handle dynamic rules object

### DIFF
--- a/addon/components/lf-form.js
+++ b/addon/components/lf-form.js
@@ -15,7 +15,6 @@ export default Component.extend({
 
   layout,
   tagName: 'form',
-  formValidator: null,
   rules: null, //passed in
   data: null, //passed in
   preventSubmit: null, //passed in
@@ -29,12 +28,15 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    this.set('formValidator', formValidator.create({
+  },
+
+  formValidator: computed('rules', 'data', function() {
+    return formValidator.create({
       container: getOwner(this),
       rules: this.get('rules'),
       data: this.get('data')
-    }));
-  },
+    });
+  }),
 
   dataChanged: observer('data', function() {
     this.get('formValidator').set('data', this.get('data'));

--- a/addon/components/lf-form.js
+++ b/addon/components/lf-form.js
@@ -8,6 +8,7 @@ const {
   computed,
   observer,
   inject: { service },
+  run,
 } = Ember;
 
 export default Component.extend({
@@ -38,8 +39,8 @@ export default Component.extend({
     });
   }),
 
-  dataChanged: observer('data', function() {
-    this.get('formValidator').set('data', this.get('data'));
+  rulesChanged: observer('rules', function() {
+    run.next(() => this.get('eventDispatcher').trigger('lf-forceValidate'));
   }),
 
   submit(e) {

--- a/addon/components/lf-form.js
+++ b/addon/components/lf-form.js
@@ -27,10 +27,6 @@ export default Component.extend({
     return false;
   }),
 
-  init() {
-    this._super(...arguments);
-  },
-
   formValidator: computed('rules', 'data', function() {
     return formValidator.create({
       container: getOwner(this),

--- a/addon/components/lf-form.js
+++ b/addon/components/lf-form.js
@@ -40,7 +40,7 @@ export default Component.extend({
   }),
 
   rulesChanged: observer('rules', function() {
-    run.next(() => this.get('eventDispatcher').trigger('lf-forceValidate'));
+    run.next(() => this.get('eventDispatcher').trigger('lf-forceValidate', false));
   }),
 
   submit(e) {

--- a/addon/mixins/lf-input-mixin.js
+++ b/addon/mixins/lf-input-mixin.js
@@ -93,10 +93,12 @@ export default Mixin.create({
     this.get('eventDispatcher').off('lf-forceValidate', this, this.onForceValidate);
   },
 
-  executeValidate() {
+  executeValidate(showValidationState = true) {
     this.set('_edited', true);
     this.validateField(this.get('property'));
-    this.showValidationState();
+    if (showValidationState) {
+      this.showValidationState();
+    }
   },
 
   /**
@@ -155,7 +157,7 @@ export default Mixin.create({
   /**
    * 'lf-forceValidate' Event handler
    */
-  onForceValidate() {
-    this.executeValidate();
+  onForceValidate(showValidationState) {
+    this.executeValidate(showValidationState);
   },
 });

--- a/tests/integration/components/lf-form-test.js
+++ b/tests/integration/components/lf-form-test.js
@@ -1,5 +1,6 @@
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
+import wait from 'ember-test-helpers/wait';
 
 moduleForComponent('lf-form', 'Integration | Component | lf-form', {
   integration: true
@@ -69,6 +70,41 @@ test('it displays errors on submit when preventSubmit=true', function(assert){
   assert.ok(this.$('.js-input').hasClass('has-error'), 'it should display error on submit');
   assert.ok(this.$('.js-textarea').hasClass('has-error'), 'it should display error on submit');
   assert.ok(this.$('.js-select').hasClass('has-error'), 'it should display error on submit');
+});
+
+test('it changes validation state of already edited field when new rules are set', function(assert){
+  assert.expect(4);
+
+  this.set('rules', {});
+
+  this.render(hbs`
+  {{#lf-form rules=rules as |v|}}
+    {{lf-input
+      class='js-input-1'
+      name='input1'
+      validate=v
+    }}
+    {{lf-input
+      class='js-input-2'
+      name='input2'
+      validate=v
+    }}
+  {{/lf-form}}`);
+
+  this.$('.js-input-1 input').val('123').change().blur();
+
+  assert.ok(this.$('.js-input-1').hasClass('has-success'), 'it should add success class to modified input');
+  assert.notOk(this.$('.js-input-2').hasClass('has-success'), 'it should not add success class to unmodified input');
+
+  this.set('rules', {
+    input1: 'required',
+    input2: 'required',
+  });
+
+  return wait().then(() => {
+    assert.ok(this.$('.js-input-1').hasClass('has-error'), 'it should add error class to modified input');
+    assert.notOk(this.$('.js-input-2').hasClass('has-error'), 'it should not add error class to unmodified input');
+  });
 });
 
 test('it allows to submit form when it\'s valid and preventSubmit=true', function(assert){


### PR DESCRIPTION
* LFForm component: `formValidator` property as computed property, instead of static instance with parameters changed in `dataChanged` observer.
* LFForm component: Adding `rulesChanged` observer, forcing form re-validation when new validation rules are supplied.
* LFInput mixin: altering re-validation handlers to accept option specifying whether all form inputs should be forced to show their validation state (even unmodified ones).
* LFForm integration spec:  _de facto_ test case for all of the above.

TL;DR: `rules` object can be computed now - making dynamic validation much easier and more powerful, without writing custom validators (assuming form values are held as controller/component properties and can be accessed by computed property).

Fixes #23 .