### PR TITLE
Remove ember-get-helper dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "dependencies": {
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-babel": "^5.1.6",
-    "ember-get-helper": "1.0.4",
     "ember-truth-helpers": "1.2.0",
     "ember-one-way-controls": "0.8.0",
     "ember-lodash": "0.0.7"


### PR DESCRIPTION
Follow-up on #25: `ember-get-helper` dependency is unnecessary ever since Ember.JS 2.0 release, which includes it by default.

Related issue: #29 .