### PR TITLE
`decimal` validator

### DIFF
--- a/addon/utils/message-provider.js
+++ b/addon/utils/message-provider.js
@@ -14,6 +14,7 @@ export default Ember.Object.extend({
     'tooLong': 'too long',
     'tooShort': 'too short',
     'mustBeNumeric': 'must be a number',
+    'mustHaveFeverDecimals': 'must have less than {{allowedDecimals}} numbers after decimal point',
     'mustMatchRegex': 'must have a proper format',
     'mustBeValidURL': 'must be a valid URL',
     "required": "can't be blank",

--- a/addon/validators/decimal-validator.js
+++ b/addon/validators/decimal-validator.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+export default Ember.Object.extend({
+  validate(value, validator) {
+    const allowedDecimals = validator && validator.get('arguments')[0];
+    const decimals = String(value).split('.')[1];
+
+    if (isNaN(value)) {
+      return 'mustBeNumeric';
+    }
+
+    if (allowedDecimals && decimals &&
+      decimals.length > allowedDecimals
+    ) {
+      return {
+        message: 'mustHaveFeverDecimals',
+        replacements: {
+          allowedDecimals,
+        },
+      };
+    }
+  }
+});

--- a/tests/unit/validators/decimal-validator-test.js
+++ b/tests/unit/validators/decimal-validator-test.js
@@ -1,0 +1,27 @@
+import validator from 'ember-legit-forms/validators/decimal-validator';
+import argumentsObj from '../../helpers/arguments-obj';
+import { module, test } from 'qunit';
+
+module('Unit | Validators | decimal');
+
+let subject = validator.create();
+
+test('it validates properly', function(assert) {
+  assert.equal(subject.validate('9.13'), undefined);
+  assert.equal(subject.validate(9.141), undefined);
+  assert.equal(subject.validate(9.141, argumentsObj(3)), undefined);
+
+  assert.equal(subject.validate('10.1a34'), 'mustBeNumeric');
+  assert.deepEqual(subject.validate('10.134', argumentsObj(2)), {
+    message: 'mustHaveFeverDecimals',
+    replacements: {
+      allowedDecimals: 2,
+    },
+  });
+});
+
+test('it allows empty values for chaining', function(assert) {
+  assert.equal(subject.validate(''), undefined);
+
+  assert.equal(subject.validate(null), undefined);
+});


### PR DESCRIPTION
New `decimal` validator to handle fields which should accept numeric values, with optional numbers present after decimal point.

Examples of usage, including comparison with existing `numeric` validator (which validates only integers):

```javascript
rules: {
  integer: 'numeric', // will allow "10"; won't allow "10.31", "10.310251", ...
  number: 'decimal', // will allow "10", "10.31", "10.310251", ...
  price: 'decimal(2) // will allow "10", "10.31"; won't allow "10.310", "10.310251", ...
}
```

Related issue: #32 .