### PR TITLE
Update ember-cli-release and ember-one-way-controls to remove deprecations

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-qunit": "^1.4.0",
-    "ember-cli-release": "0.2.8",
+    "ember-cli-release": "1.0.0-beta.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.5.0",
@@ -53,7 +53,7 @@
     "ember-cli-babel": "^5.1.6",
     "ember-truth-helpers": "1.2.0",
     "ember-sinon": "0.6.0",
-    "ember-one-way-controls": "0.8.0",
+    "ember-one-way-controls": "2.0.0",
     "ember-lodash": "0.0.7"
   },
   "ember-addon": {


### PR DESCRIPTION
This passed all the tests, so hopefully it's not a big swap.

I was gonna try the baseURL/rootURL deprecation, but it wasn't as dead-simple as replacing.

edit: attaching issue #10 