### PR TITLE
E-mail validator: using native browser-based validation when available.

### DIFF
--- a/addon/validators/email-validator.js
+++ b/addon/validators/email-validator.js
@@ -6,9 +6,17 @@ export default Ember.Object.extend({
   validate(value) {
     if (isBlank(value)) { return; }
 
-    let emailRegex = /^[-a-z0-9~!$%^&*_=+}{\'?]+(\.[-a-z0-9~!$%^&*_=+}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.(aero|arpa|biz|com|coop|edu|gov|info|int|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i;
+    const input = document.createElement('input');
+    input.type = 'email';
+    input.value = value;
 
-    if (!emailRegex.test(value)) {
+    const emailRegex = /^[-a-z0-9~!$%^&*_=+}{\'?]+(\.[-a-z0-9~!$%^&*_=+}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.(aero|arpa|biz|com|coop|edu|gov|info|int|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i;
+
+    const isValid = typeof input.checkValidity === 'function' ?
+      input.checkValidity() :
+      emailRegex.test(value);
+
+    if (!isValid) {
       return 'mustBeValidEmail';
     }
   }


### PR DESCRIPTION
E-mail validator: delegate e-mail validation to built-in browser functionality, with regex-based check staying only as fallback for IE9 (see [Can I use](http://caniuse.com/#feat=input-email-tel-url) support table).

Fixes #20.