### PR TITLE
LFInput: allow passing-in name of input component to be used instead of default one-way-input.

### DIFF
--- a/addon/components/lf-input.js
+++ b/addon/components/lf-input.js
@@ -20,6 +20,8 @@ export default Component.extend(LFInputMixin, {
     }
   }),
 
+  inputComponent: 'one-way-input',
+
   focusOut() {
     this.set('_edited', true);
     let value = isNone(this.get('_value')) ? this.get('property') : this.get('_value');

--- a/addon/templates/components/lf-input.hbs
+++ b/addon/templates/components/lf-input.hbs
@@ -11,7 +11,7 @@
       {{#if (eq addonPlacement 'before')}}
         {{yield}}
       {{/if}}
-      {{one-way-input
+      {{component inputComponent
         id=id
         value=property
         update=(action "valueChanged")
@@ -26,7 +26,7 @@
       {{/if}}
     </div>
   {{else}}
-      {{one-way-input
+      {{component inputComponent
         id=id
         value=property
         update=(action "valueChanged")

--- a/tests/dummy/app/templates/components/custom-input-component.hbs
+++ b/tests/dummy/app/templates/components/custom-input-component.hbs
@@ -1,0 +1,4 @@
+{{input
+  type="text"
+  class="custom-input-component"
+}}

--- a/tests/integration/components/lf-input-test.js
+++ b/tests/integration/components/lf-input-test.js
@@ -47,6 +47,21 @@ test('it has proper `for` attribute set on label', function(assert) {
     'it has proper `for` attribute set');
 });
 
+test('it uses custom input component', function(assert) {
+  setupInput(this);
+
+  this.render(hbs`{{lf-input
+    label="Name"
+    property=name
+    name="name"
+    validate=(action validateAction)
+    on-update=(action onUpdate)
+    inputComponent='custom-input-component'
+  }}`);
+
+  assert.ok(this.$('.custom-input-component').length, 'it uses custom input component');
+});
+
 test('it passes custom `id` to inner input and label', function(assert) {
   setupInput(this);
 


### PR DESCRIPTION
Resolves https://github.com/jbandura/ember-legit-forms/issues/43 .