### PR TITLE
Pass optional content to the inputComponent

### DIFF
--- a/addon/templates/components/lf-input.hbs
+++ b/addon/templates/components/lf-input.hbs
@@ -14,6 +14,7 @@
       {{component inputComponent
         id=id
         value=property
+        content=content
         update=(action "valueChanged")
         placeholder=placeholder
         type=type
@@ -49,6 +50,7 @@
       {{component inputComponent
         id=id
         value=property
+        content=content
         update=(action "valueChanged")
         placeholder=placeholder
         type=type


### PR DESCRIPTION
In dynamically generated forms (ie. from Model or other data) this allows the inputComponent’s options to be dynamic too. 