### PR TITLE
Removing `isBlank` check

### DIFF
--- a/addon/validators/same-validator.js
+++ b/addon/validators/same-validator.js
@@ -3,8 +3,6 @@ import { isBlank } from '@ember/utils';
 
 export default EmberObject.extend({
   validate(value, validator) {
-    if (isBlank(value)) { return; }
-
     let [fieldName] = get(validator, 'arguments');
 
     if(value !== get(validator, `field:${fieldName}`)) {

--- a/addon/validators/same-validator.js
+++ b/addon/validators/same-validator.js
@@ -1,5 +1,4 @@
 import EmberObject, { get } from '@ember/object';
-import { isBlank } from '@ember/utils';
 
 export default EmberObject.extend({
   validate(value, validator) {

--- a/tests/unit/validators/same-validator-test.js
+++ b/tests/unit/validators/same-validator-test.js
@@ -28,10 +28,9 @@ test('it validates properly', function(assert) {
     subject.validate('foo', argumentsObj('address', 'asd')).message,
     'mustBeSame'
   );
-});
-
-test('it allows empty values for chaining', function(assert) {
-  assert.equal(subject.validate(''), undefined);
-
-  assert.equal(subject.validate(null), undefined);
+  
+  assert.equal(
+    subject.validate('foo', argumentsObj('address', '')).message,
+    'mustBeSame'
+  );
 });


### PR DESCRIPTION
When checking for `isBlank` while using `same` leads to validating a field that is empty even when the field it's being validated against has data in it.

e.g: `password` and `confirmPassword`. `password` has `12345678` and `confirmPassword` is `null` and it will still validate it as correct.